### PR TITLE
Fix parse_inset in gui.lua

### DIFF
--- a/library/lua/gui.lua
+++ b/library/lua/gui.lua
@@ -105,7 +105,7 @@ local function parse_inset(inset)
         l = inset or 0
         t,r,b = l,l,l
     end
-    return l,r,t,b
+    return l,t,r,b
 end
 
 function inset_frame(rect, inset, gap)


### PR DESCRIPTION
It was used in different order than the return happened.